### PR TITLE
chore: add sidekick config to enable block library tool

### DIFF
--- a/tools/sidekick/config.js
+++ b/tools/sidekick/config.js
@@ -1,0 +1,34 @@
+window.hlx.initSidekick({
+  project: 'Unilever - Dove',
+  libraries: [
+    {
+      text: 'Blocks',
+      paths: [
+        'https://main--dove--hlxsites.hlx.page/library/blocks/blocks.json',
+      ],
+    },
+  ],
+  plugins: [
+    {
+      id: 'library',
+      condition: () => true,
+      button: {
+        text: 'Library',
+        action: (_, s) => {
+          const domain = 'https://main--milo--adobecom.hlx.page';
+          const { config } = s;
+          const script = document.createElement('script');
+          script.type = 'module';
+          script.onload = () => {
+            const skEvent = new CustomEvent('hlx:library-loaded', {
+              detail: { domain, libraries: config.libraries },
+            });
+            document.dispatchEvent(skEvent);
+          };
+          script.src = `${domain}/libs/ui/library/library.js`;
+          document.head.appendChild(script);
+        },
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Adds the block library tool (referenced from Milo project)

For testing configure the sidekick with https://github.com/hlxsites/dove/tree/block-library-sidekick

https://block-library-sidekick--dove--hlxsites.hlx.page/